### PR TITLE
Fix task card sizing

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -366,8 +366,11 @@ button {
 }
 
 .task-list {
+  align-content: start;
+  align-items: start;
   display: grid;
   gap: 10px;
+  grid-auto-rows: max-content;
   padding: 12px;
 }
 
@@ -377,6 +380,7 @@ button {
 }
 
 .task-card {
+  align-self: start;
   background: var(--surface);
   border: 1px solid #d8dde4;
   border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- Keep task cards sized to their content instead of stretching to fill the column height.
- Align task list grid rows to the top of each column.

## Validation
- `node --check server.mjs`
- Browser verification confirmed task cards render with content-based heights on the running board.