### PR TITLE
[codex] Update task modal and done workflow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -12,6 +12,9 @@ const els = {
   codexStatusBody: document.querySelector("#codex-status-body"),
   codexStatusTitle: document.querySelector("#codex-status-title"),
   deleteTaskButton: document.querySelector("#delete-task-button"),
+  doneHistoryList: document.querySelector("#done-history-list"),
+  doneHistoryModal: document.querySelector("#done-history-modal"),
+  doneHistoryTitle: document.querySelector("#done-history-title"),
   githubIssueLink: document.querySelector("#github-issue-link"),
   githubStatusBody: document.querySelector("#github-status-body"),
   githubStatusTitle: document.querySelector("#github-status-title"),
@@ -30,6 +33,7 @@ const els = {
   proposalSummary: document.querySelector("#proposal-summary"),
   requestReviewButton: document.querySelector("#request-review-button"),
   requestChangesButton: document.querySelector("#request-changes-button"),
+  reviewStatusValue: document.querySelector("#review-status-value"),
   resultCard: document.querySelector("#result-card"),
   resultChangedPaths: document.querySelector("#result-changed-paths"),
   resultDetails: document.querySelector("#result-details"),
@@ -40,15 +44,21 @@ const els = {
   searchInput: document.querySelector("#search-input"),
   sendCodexButton: document.querySelector("#send-codex-button"),
   sendGithubButton: document.querySelector("#send-github-button"),
+  saveTaskButton: document.querySelector("#save-task-button"),
   syncGithubButton: document.querySelector("#sync-github-button"),
   statsGrid: document.querySelector("#stats-grid"),
   taskAcceptance: document.querySelector("#task-acceptance"),
   taskColumn: document.querySelector("#task-column"),
+  taskContextInput: document.querySelector("#task-context-input"),
+  taskContextPreview: document.querySelector("#task-context-preview"),
   taskDescription: document.querySelector("#task-description"),
+  taskEditFields: document.querySelector("#task-edit-fields"),
   taskEnvironment: document.querySelector("#task-environment"),
   taskForm: document.querySelector("#task-form"),
   taskGithubRepo: document.querySelector("#task-github-repo"),
   taskId: document.querySelector("#task-id"),
+  taskInputSummary: document.querySelector("#task-input-summary"),
+  taskInputSummaryBody: document.querySelector("#task-input-summary-body"),
   taskLabels: document.querySelector("#task-labels"),
   taskLinks: document.querySelector("#task-links"),
   taskModal: document.querySelector("#task-modal"),
@@ -59,12 +69,14 @@ const els = {
   taskSize: document.querySelector("#task-size"),
   taskTitle: document.querySelector("#task-title"),
   toast: document.querySelector("#toast"),
+  workStatusValue: document.querySelector("#work-status-value"),
 };
 
 let store = null;
 let currentProjectId = null;
 let draggedTaskId = null;
 let toastTimer = null;
+let contextImagesDraft = [];
 let accessToken = window.localStorage.getItem(tokenStorageKey) ?? "";
 
 async function api(path, options = {}) {
@@ -160,6 +172,60 @@ function latestResultForTask(taskId) {
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
 }
 
+function completedAtValue(task) {
+  return task?.completedAt || task?.githubIssueClosedAt || task?.updatedAt || task?.createdAt || "";
+}
+
+function reviewStatusLabel(task) {
+  const status = task?.codexReviewStatus ?? "idle";
+
+  if (["requested", "claimed", "cloud-triggered"].includes(status)) {
+    return "In progress";
+  }
+
+  if (status === "proposed") {
+    return "Ready";
+  }
+
+  if (status === "applied") {
+    return "Applied";
+  }
+
+  return "Not done";
+}
+
+function workStatusLabel(task) {
+  if (!task) {
+    return "Not started";
+  }
+
+  if (task.columnId === "done") {
+    return "Done";
+  }
+
+  if (task.columnId === "review" || task.codexResultStatus === "ready-for-review") {
+    return "Ready for review";
+  }
+
+  if (["claimed", "cloud-triggered"].includes(task.codexHandoffStatus) || task.githubStatus === "codex-triggered") {
+    return "In progress";
+  }
+
+  if (task.codexHandoffStatus === "requested" || task.columnId === "ready") {
+    return "Ready";
+  }
+
+  return "Not started";
+}
+
+function isResultMode(task) {
+  return Boolean(task && ["review", "done"].includes(task.columnId));
+}
+
+function currentModalTask() {
+  return store?.tasks.find((task) => task.id === els.taskId.value) ?? null;
+}
+
 function taskActivities(taskId) {
   return (store.activities ?? [])
     .filter((activity) => activity.taskId === taskId)
@@ -216,6 +282,89 @@ function createEl(tagName, className, content) {
   }
 
   return el;
+}
+
+function normalizeContextImage(image) {
+  if (!image) {
+    return null;
+  }
+
+  if (typeof image === "string") {
+    return {
+      id: `context-${Math.random().toString(36).slice(2)}`,
+      name: "Screenshot",
+      src: image,
+      type: "image",
+    };
+  }
+
+  const src = text(image.src);
+  if (!src) {
+    return null;
+  }
+
+  return {
+    id: text(image.id) || `context-${Math.random().toString(36).slice(2)}`,
+    name: text(image.name) || "Screenshot",
+    src,
+    type: text(image.type) || "image",
+    size: Number(image.size) || undefined,
+    createdAt: text(image.createdAt) || new Date().toISOString(),
+  };
+}
+
+function taskContextImages(task) {
+  return (task?.contextImages ?? []).map(normalizeContextImage).filter(Boolean);
+}
+
+function fileToContextImage(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      resolve({
+        id: `context-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        name: file.name,
+        src: reader.result,
+        type: file.type,
+        size: file.size,
+        createdAt: new Date().toISOString(),
+      });
+    });
+    reader.addEventListener("error", () => reject(new Error(`Could not read ${file.name}`)));
+    reader.readAsDataURL(file);
+  });
+}
+
+function renderContextPreview(target, images, { removable = false } = {}) {
+  target.replaceChildren();
+  const values = (images ?? []).map(normalizeContextImage).filter(Boolean);
+
+  if (!values.length) {
+    target.append(createEl("p", "empty-list-item", "No screenshots added."));
+    return;
+  }
+
+  for (const image of values) {
+    const item = createEl("figure", "context-image");
+    const preview = document.createElement("img");
+    preview.src = image.src;
+    preview.alt = image.name;
+    const caption = createEl("figcaption", "", image.name);
+    item.append(preview, caption);
+
+    if (removable) {
+      const remove = createEl("button", "icon-button", "x");
+      remove.type = "button";
+      remove.setAttribute("aria-label", `Remove ${image.name}`);
+      remove.addEventListener("click", () => {
+        contextImagesDraft = contextImagesDraft.filter((candidate) => candidate.id !== image.id);
+        renderContextPreview(els.taskContextPreview, contextImagesDraft, { removable: true });
+      });
+      item.append(remove);
+    }
+
+    target.append(item);
+  }
 }
 
 function formatDateTime(value) {
@@ -384,9 +533,13 @@ function renderBoard() {
     titleRow.append(createEl("h3", "", column.name), createEl("span", "task-count", String(count)));
     header.append(titleRow, createEl("p", "column-description", column.description));
 
-    const columnTasks = tasks
+    const allColumnTasks = tasks
       .filter((task) => task.columnId === column.id)
       .sort((left, right) => (left.sortOrder ?? 0) - (right.sortOrder ?? 0));
+    const columnTasks =
+      column.id === "done"
+        ? [...allColumnTasks].sort((left, right) => completedAtValue(right).localeCompare(completedAtValue(left))).slice(0, 10)
+        : allColumnTasks;
 
     if (!columnTasks.length) {
       list.append(createEl("p", "empty-column", "No tasks"));
@@ -396,6 +549,13 @@ function renderBoard() {
       }
     }
 
+    if (column.id === "done" && allColumnTasks.length > 10) {
+      const historyButton = createEl("button", "history-button", `View ${allColumnTasks.length - 10} older`);
+      historyButton.type = "button";
+      historyButton.addEventListener("click", () => openDoneHistory());
+      list.append(historyButton);
+    }
+
     columnEl.append(header, list);
     els.board.append(columnEl);
   }
@@ -403,6 +563,7 @@ function renderBoard() {
 
 function renderTaskCard(task) {
   const card = createEl("article", "task-card");
+  card.classList.toggle("task-card-compact", task.columnId === "done");
   card.draggable = true;
   card.tabIndex = 0;
   card.addEventListener("click", () => openTaskModal(task));
@@ -421,6 +582,12 @@ function renderTaskCard(task) {
   });
 
   const title = createEl("h4", "", task.title);
+  if (task.columnId === "done") {
+    const completed = createEl("span", "completed-date", completedAtValue(task) ? `Completed ${formatDateTime(completedAtValue(task))}` : "Completed");
+    card.append(title, completed);
+    return card;
+  }
+
   const description = createEl("p", "", task.description);
   const meta = createEl("div", "task-meta");
   const priority = createEl("span", `pill ${task.priority.toLowerCase()}`, task.priority);
@@ -511,7 +678,42 @@ function renderTaskCard(task) {
   return card;
 }
 
+function openDoneHistory() {
+  const project = currentProject();
+  const doneTasks = allProjectTasks()
+    .filter((task) => task.columnId === "done")
+    .sort((left, right) => completedAtValue(right).localeCompare(completedAtValue(left)));
+
+  els.doneHistoryTitle.textContent = project ? `${project.name} completed tasks` : "Completed tasks";
+  els.doneHistoryList.replaceChildren();
+
+  if (!doneTasks.length) {
+    els.doneHistoryList.append(createEl("li", "empty-list-item", "No completed tasks."));
+  } else {
+    for (const task of doneTasks) {
+      const item = createEl("li", "history-item");
+      const button = createEl("button", "", task.title);
+      button.type = "button";
+      button.addEventListener("click", () => {
+        els.doneHistoryModal.close();
+        openTaskModal(task);
+      });
+      const completed = createEl("span", "", completedAtValue(task) ? formatDateTime(completedAtValue(task)) : "No completion time");
+      item.append(button, completed);
+      els.doneHistoryList.append(item);
+    }
+  }
+
+  if (!els.doneHistoryModal.open) {
+    els.doneHistoryModal.showModal();
+  }
+}
+
 function fillColumnOptions(selectedColumnId) {
+  if (!els.taskColumn) {
+    return;
+  }
+
   els.taskColumn.replaceChildren();
 
   for (const column of store.columns) {
@@ -528,11 +730,12 @@ function renderCodexPanel(task) {
   els.proposalDetails.replaceChildren();
   els.applyReviewButton.dataset.reviewId = "";
   els.sendCodexButton.textContent = "Send to Codex";
+  els.reviewStatusValue.textContent = reviewStatusLabel(task);
+  els.workStatusValue.textContent = workStatusLabel(task);
 
   if (!task) {
-    els.codexStatusTitle.textContent = "Ready when the card is saved";
-    els.codexStatusBody.textContent =
-      "Save or send this task to create a Codex-readable packet without copy-paste.";
+    els.codexStatusTitle.textContent = "Draft task";
+    els.codexStatusBody.textContent = "Save the task before requesting a review or sending it to Codex.";
     return;
   }
 
@@ -540,76 +743,63 @@ function renderCodexPanel(task) {
   const handoff = latestHandoffForTask(task.id);
 
   if (task.githubStatus === "codex-triggered" || task.codexHandoffStatus === "cloud-triggered") {
-    els.codexStatusTitle.textContent = "Codex Cloud is working";
-    els.codexStatusBody.textContent =
-      "The task is running through the GitHub/Codex Cloud path. The board will sync the result back into Review.";
-    els.sendCodexButton.textContent = "Send to local Codex";
+    els.codexStatusTitle.textContent = "Codex is working";
+    els.codexStatusBody.textContent = "The task is in progress. Results will appear when Codex completes the work.";
     return;
   }
 
   if (task.codexHandoffStatus === "completed" || task.codexResultStatus === "ready-for-review") {
-    els.codexStatusTitle.textContent = "Codex result is ready";
-    els.codexStatusBody.textContent =
-      "The task has moved to Review with a read-only result for you to accept or send back for changes.";
-    els.sendCodexButton.textContent = "Resend to Codex";
+    els.codexStatusTitle.textContent = "Result ready";
+    els.codexStatusBody.textContent = "Review the result below, then confirm it or provide further directions.";
     return;
   }
 
   if (review?.status === "proposed" && review.proposal && !["doing", "review", "done"].includes(task.columnId)) {
-    els.codexStatusTitle.textContent = "Codex review proposal is ready";
-    els.codexStatusBody.textContent = "Review the proposed task shape below, then apply it before sending the task to Codex.";
-    renderProposal(review);
+    els.codexStatusTitle.textContent = "Review ready";
+    els.codexStatusBody.textContent = "A task review is ready to apply before implementation starts.";
     return;
   }
 
   if (review?.status === "requested") {
-    els.codexStatusTitle.textContent = "Task review requested";
-    els.codexStatusBody.textContent =
-      "The task is in the Codex review queue. Ask me to review the next task when you want a proposal.";
+    els.codexStatusTitle.textContent = "Review requested";
+    els.codexStatusBody.textContent = "The task is waiting for a Codex readiness review.";
     return;
   }
 
   if (review?.status === "cloud-triggered" || task.codexReviewStatus === "cloud-triggered") {
-    els.codexStatusTitle.textContent = "Codex Cloud is reviewing";
-    els.codexStatusBody.textContent =
-      `A review-only @codex request is running in ${task.githubRepo ?? "GitHub"}. The proposal will appear here after sync.`;
+    els.codexStatusTitle.textContent = "Review in progress";
+    els.codexStatusBody.textContent = "A review-only Codex request is running.";
     return;
   }
 
   if (review?.status === "claimed" || task.codexReviewStatus === "claimed") {
-    els.codexStatusTitle.textContent = "Codex is reviewing this task";
-    els.codexStatusBody.textContent =
-      "The review has been claimed. A proposal will appear here when it is posted back to the card.";
+    els.codexStatusTitle.textContent = "Review in progress";
+    els.codexStatusBody.textContent = "Codex has claimed the review.";
     return;
   }
 
   if (task.codexHandoffStatus === "changes-requested" || task.codexResultStatus === "changes-requested") {
-    els.codexStatusTitle.textContent = "Changes requested";
-    els.codexStatusBody.textContent =
-      "Update the card with your final guidance, then send it to Codex again when it is ready.";
-    els.sendCodexButton.textContent = "Send revised task";
+    els.codexStatusTitle.textContent = "Further directions sent";
+    els.codexStatusBody.textContent = "The task has been sent back to In Progress.";
     return;
   }
 
   if (task.codexHandoffStatus === "accepted" || task.codexResultStatus === "accepted") {
-    els.codexStatusTitle.textContent = "Task accepted";
+    els.codexStatusTitle.textContent = "Task confirmed";
     els.codexStatusBody.textContent = "The result has been accepted and the task is done.";
-    els.sendCodexButton.textContent = "Resend to Codex";
     return;
   }
 
   if (hasActiveLocalHandoff(task, handoff) && handoff.status === "requested") {
     els.codexStatusTitle.textContent = "Task sent to Codex";
-    els.codexStatusBody.textContent =
-      "The task is in Ready and queued for Codex. A Codex instance can claim the next queued task without pasting the card.";
+    els.codexStatusBody.textContent = "The task is queued for local Codex.";
     els.sendCodexButton.textContent = "Resend to Codex";
     return;
   }
 
   if ((hasActiveLocalHandoff(task, handoff) && handoff.status === "claimed") || (task.codexHandoffStatus === "claimed" && !hasCloudWorkflow(task))) {
     els.codexStatusTitle.textContent = "Codex is working on this task";
-    els.codexStatusBody.textContent =
-      "The handoff has been claimed and the task has moved into In Progress.";
+    els.codexStatusBody.textContent = "The handoff has been claimed.";
     els.sendCodexButton.textContent = "Resend to Codex";
     return;
   }
@@ -622,8 +812,7 @@ function renderCodexPanel(task) {
   }
 
   els.codexStatusTitle.textContent = "No Codex activity yet";
-  els.codexStatusBody.textContent =
-    "Request a task review to shape the card first, or send it directly when it is ready.";
+  els.codexStatusBody.textContent = "Request a task review or send the task to Codex when it is ready.";
 }
 
 function renderProposal(review) {
@@ -656,8 +845,9 @@ function renderProposal(review) {
 function renderGithubPanel(task) {
   els.githubIssueLink.hidden = true;
   els.githubIssueLink.href = "#";
+  els.sendGithubButton.hidden = true;
   els.sendGithubButton.textContent = "Send to GitHub/Codex Cloud";
-  els.syncGithubButton.hidden = !task?.githubIssueUrl || task?.githubStatus === "accepted";
+  els.syncGithubButton.hidden = true;
   els.syncGithubButton.dataset.taskId = task?.id ?? "";
   els.syncGithubButton.textContent = task?.githubStatus === "completed" ? "Sync again" : "Check GitHub result";
 
@@ -717,6 +907,23 @@ function renderGithubPanel(task) {
     `Create a GitHub issue from this card and optionally trigger Codex Cloud without using this local chat.${targetText}${environmentText}`;
 }
 
+function stripCodexCommentary(value) {
+  const body = text(value).trim();
+
+  if (!body) {
+    return "";
+  }
+
+  const resultMatch = body.match(/(?:^|\n)#{2,3}\s*Result\s*\n([\s\S]*?)(?=\n#{2,3}\s*(Summary|Testing|Verification|Changed paths|Follow-ups|Notes|$))/i);
+  if (resultMatch?.[1]?.trim()) {
+    return resultMatch[1].trim();
+  }
+
+  return body
+    .replace(/\n#{2,3}\s*(Summary|Testing|Verification|Verification notes|Changed paths|Follow-ups|Pull requests?|GitHub)[\s\S]*$/i, "")
+    .trim();
+}
+
 function renderResultPanel(task) {
   const result = task ? latestResultForTask(task.id) : null;
   const resultIsClosed =
@@ -730,6 +937,8 @@ function renderResultPanel(task) {
   els.resultGithubLink.href = "#";
   els.acceptTaskButton.hidden = resultIsClosed;
   els.requestChangesButton.hidden = resultIsClosed;
+  els.acceptTaskButton.textContent = "Confirm result";
+  els.requestChangesButton.textContent = "Further directions";
   els.acceptTaskButton.dataset.taskId = task?.id ?? "";
   els.requestChangesButton.dataset.taskId = task?.id ?? "";
 
@@ -738,7 +947,7 @@ function renderResultPanel(task) {
   }
 
   els.resultSummary.textContent = result.summary || "Codex completed the task.";
-  els.resultDetails.textContent = result.details || "No additional detail recorded.";
+  els.resultDetails.textContent = stripCodexCommentary(result.details) || "No result text recorded.";
   if (result.githubCommentUrl || result.codexTaskUrl || result.githubIssueUrl) {
     els.resultGithubLink.href = result.githubCommentUrl || result.codexTaskUrl || result.githubIssueUrl;
     els.resultGithubLink.hidden = false;
@@ -777,60 +986,80 @@ function renderActivityPanel(task) {
   }
 }
 
+function renderInputSummary(task) {
+  els.taskInputSummaryBody.replaceChildren();
+
+  if (!task) {
+    return;
+  }
+
+  const rows = [
+    ["Title", task.title],
+    ["Description", task.description || "No description."],
+    ["Acceptance criteria", (task.acceptanceCriteria ?? []).join("\n") || "No acceptance criteria."],
+  ];
+
+  for (const [label, value] of rows) {
+    const group = createEl("div", "summary-row");
+    group.append(createEl("strong", "", label), createEl("p", "", value));
+    els.taskInputSummaryBody.append(group);
+  }
+
+  const images = taskContextImages(task);
+  if (images.length) {
+    const group = createEl("div", "summary-row");
+    const preview = createEl("div", "context-preview");
+    group.append(createEl("strong", "", "Screenshot context"), preview);
+    els.taskInputSummaryBody.append(group);
+    renderContextPreview(preview, images);
+  }
+}
+
 function openTaskModal(task = null) {
   const fallbackColumn = "backlog";
+  const resultMode = isResultMode(task);
 
   els.taskId.value = task?.id ?? "";
   els.taskTitle.value = text(task?.title);
   els.taskDescription.value = text(task?.description);
-  els.taskGithubRepo.value = text(task?.githubRepo);
-  els.taskGithubRepo.placeholder = currentProject()?.githubRepo
-    ? `${currentProject().githubRepo} (project default)`
-    : "owner/repo";
-  els.taskEnvironment.value = text(task?.targetEnvironment);
-  els.taskPriority.value = task?.priority ?? "Medium";
-  els.taskSize.value = task?.size ?? "M";
-  els.taskLabels.value = (task?.labels ?? []).join(", ");
   els.taskAcceptance.value = (task?.acceptanceCriteria ?? []).join("\n");
-  els.taskLinks.value = (task?.links ?? []).join("\n");
-  els.taskNotes.value = text(task?.notes);
+  contextImagesDraft = taskContextImages(task);
+  renderContextPreview(els.taskContextPreview, contextImagesDraft, { removable: true });
   els.taskModalKicker.textContent = currentProject()?.name ?? "Task";
-  els.taskModalTitle.textContent = task ? "Edit task" : "New task";
-  els.deleteTaskButton.hidden = !task;
+  els.taskModalTitle.textContent = task ? (resultMode ? "Task result" : "Edit task") : "New task";
+  els.deleteTaskButton.hidden = !task || resultMode;
   fillColumnOptions(task?.columnId ?? fallbackColumn);
+  els.taskEditFields.hidden = resultMode;
+  els.taskInputSummary.hidden = !resultMode;
+  renderInputSummary(task);
   renderCodexPanel(task);
   renderGithubPanel(task);
   renderResultPanel(task);
   renderActivityPanel(task);
+  els.requestReviewButton.hidden = resultMode;
+  els.sendCodexButton.hidden = resultMode;
+  els.saveTaskButton.hidden = resultMode;
   if (!els.taskModal.open) {
     els.taskModal.showModal();
   }
-  els.taskTitle.focus();
+  if (!resultMode) {
+    els.taskTitle.focus();
+  }
 }
 
 function readTaskForm() {
+  const task = currentModalTask();
+
   return {
-    projectId: currentProjectId,
-    columnId: els.taskColumn.value,
+    projectId: task?.projectId ?? currentProjectId,
+    columnId: task?.columnId ?? "backlog",
     title: els.taskTitle.value.trim(),
     description: els.taskDescription.value.trim(),
-    priority: els.taskPriority.value,
-    size: els.taskSize.value,
-    githubRepo: els.taskGithubRepo.value.trim(),
-    targetEnvironment: els.taskEnvironment.value.trim(),
-    labels: els.taskLabels.value
-      .split(",")
-      .map((label) => label.trim())
-      .filter(Boolean),
     acceptanceCriteria: els.taskAcceptance.value
       .split("\n")
       .map((item) => item.trim())
       .filter(Boolean),
-    links: els.taskLinks.value
-      .split("\n")
-      .map((link) => link.trim())
-      .filter(Boolean),
-    notes: els.taskNotes.value.trim(),
+    contextImages: contextImagesDraft,
   };
 }
 
@@ -861,6 +1090,8 @@ async function persistTaskFromForm() {
 
   if (savedTask) {
     els.taskId.value = savedTask.id;
+    contextImagesDraft = taskContextImages(savedTask);
+    renderContextPreview(els.taskContextPreview, contextImagesDraft, { removable: true });
     renderCodexPanel(savedTask);
     renderGithubPanel(savedTask);
     renderResultPanel(savedTask);
@@ -873,6 +1104,33 @@ async function persistTaskFromForm() {
 els.searchInput.addEventListener("input", renderBoard);
 
 els.newTaskButton.addEventListener("click", () => openTaskModal());
+
+els.taskContextInput.addEventListener("change", async () => {
+  const files = Array.from(els.taskContextInput.files ?? []);
+
+  if (!files.length) {
+    return;
+  }
+
+  try {
+    for (const file of files) {
+      if (!file.type.startsWith("image/")) {
+        throw new Error(`${file.name} is not an image.`);
+      }
+
+      if (file.size > 1_500_000) {
+        throw new Error(`${file.name} is larger than 1.5 MB.`);
+      }
+    }
+
+    const images = await Promise.all(files.map(fileToContextImage));
+    contextImagesDraft = [...contextImagesDraft, ...images];
+    renderContextPreview(els.taskContextPreview, contextImagesDraft, { removable: true });
+    els.taskContextInput.value = "";
+  } catch (error) {
+    showToast(error.message);
+  }
+});
 
 els.newProjectButton.addEventListener("click", () => {
   els.projectName.value = "";
@@ -1077,7 +1335,7 @@ els.acceptTaskButton.addEventListener("click", async () => {
     if (task) {
       openTaskModal(task);
     }
-    showToast(closeGithubIssue ? "Task done and GitHub issue closed" : "Task moved to Done");
+    showToast(closeGithubIssue ? "Task confirmed and GitHub issue closed" : "Task confirmed");
   } catch (error) {
     showToast(error.message);
   }
@@ -1090,7 +1348,7 @@ els.requestChangesButton.addEventListener("click", async () => {
     return;
   }
 
-  const note = window.prompt("What should Codex change?", "");
+  const note = window.prompt("What further direction should Codex follow?", "");
 
   if (note === null) {
     return;

--- a/public/index.html
+++ b/public/index.html
@@ -68,45 +68,10 @@
 
         <input id="task-id" name="id" type="hidden" />
 
-        <div class="form-grid">
+        <div class="form-grid" id="task-edit-fields">
           <label class="field field-wide">
             <span>Title</span>
             <input id="task-title" name="title" required />
-          </label>
-
-          <label class="field">
-            <span>Status</span>
-            <select id="task-column" name="columnId"></select>
-          </label>
-
-          <label class="field">
-            <span>Priority</span>
-            <select id="task-priority" name="priority">
-              <option>High</option>
-              <option>Medium</option>
-              <option>Low</option>
-            </select>
-          </label>
-
-          <label class="field">
-            <span>Size</span>
-            <select id="task-size" name="size">
-              <option>XS</option>
-              <option>S</option>
-              <option selected>M</option>
-              <option>L</option>
-              <option>XL</option>
-            </select>
-          </label>
-
-          <label class="field field-wide">
-            <span>Repository override</span>
-            <input id="task-github-repo" name="githubRepo" placeholder="owner/repo (blank uses project default)" />
-          </label>
-
-          <label class="field field-wide">
-            <span>Environment guidance</span>
-            <textarea id="task-environment" name="targetEnvironment" rows="2" placeholder="Codex environment, branch, deployment target, or repo-specific notes"></textarea>
           </label>
 
           <label class="field field-wide">
@@ -119,27 +84,34 @@
             <textarea id="task-acceptance" name="acceptanceCriteria" rows="4"></textarea>
           </label>
 
-          <label class="field">
-            <span>Labels</span>
-            <input id="task-labels" name="labels" placeholder="ux, qa, backend" />
-          </label>
-
-          <label class="field">
-            <span>Links</span>
-            <textarea id="task-links" name="links" rows="3"></textarea>
-          </label>
-
           <label class="field field-wide">
-            <span>Notes</span>
-            <textarea id="task-notes" name="notes" rows="3"></textarea>
+            <span>Screenshot context</span>
+            <input id="task-context-input" type="file" accept="image/*" multiple />
           </label>
+
+          <div class="context-preview field-wide" id="task-context-preview"></div>
         </div>
 
-        <section class="codex-panel" id="codex-panel" aria-label="Codex workflow">
+        <details class="input-summary" id="task-input-summary" hidden>
+          <summary>Input parameters</summary>
+          <div class="input-summary-body" id="task-input-summary-body"></div>
+        </details>
+
+        <section class="status-panel" id="codex-panel" aria-label="Task status">
           <div>
-            <p class="eyebrow">Codex workflow</p>
+            <p class="eyebrow">Status</p>
             <h3 id="codex-status-title">No Codex activity yet</h3>
             <p id="codex-status-body"></p>
+          </div>
+          <div class="status-grid">
+            <div>
+              <span>Review</span>
+              <strong id="review-status-value">Not done</strong>
+            </div>
+            <div>
+              <span>Work</span>
+              <strong id="work-status-value">Not started</strong>
+            </div>
           </div>
           <div class="proposal-card" id="proposal-card" hidden>
             <h4>Review proposal</h4>
@@ -149,7 +121,7 @@
           </div>
         </section>
 
-        <section class="github-panel" id="github-panel" aria-label="GitHub workflow">
+        <section class="github-panel" id="github-panel" aria-label="GitHub workflow" hidden>
           <div>
             <p class="eyebrow">GitHub cloud handoff</p>
             <h3 id="github-status-title">Not sent to GitHub</h3>
@@ -177,7 +149,7 @@
             Open GitHub result
           </a>
 
-          <div class="result-grid">
+          <div class="result-grid" hidden>
             <div>
               <h4>Changed paths</h4>
               <ul id="result-changed-paths"></ul>
@@ -202,10 +174,25 @@
           <button class="ghost-button danger" id="delete-task-button" type="button">Delete</button>
           <button class="ghost-button" id="request-review-button" type="button">Request task review</button>
           <button class="ghost-button" id="send-codex-button" type="button">Send to Codex</button>
-          <button class="ghost-button" id="send-github-button" type="button">Send to GitHub/Codex Cloud</button>
-          <button class="ghost-button" id="sync-github-button" type="button">Sync GitHub result</button>
-          <button class="primary-button" type="submit">Save task</button>
+          <button class="ghost-button" id="send-github-button" type="button" hidden>Send to GitHub/Codex Cloud</button>
+          <button class="ghost-button" id="sync-github-button" type="button" hidden>Sync GitHub result</button>
+          <button class="primary-button" id="save-task-button" type="submit">Save task</button>
         </div>
+      </form>
+    </dialog>
+
+    <dialog class="modal" id="done-history-modal">
+      <form class="modal-panel" method="dialog">
+        <div class="modal-header">
+          <div>
+            <p class="eyebrow">History</p>
+            <h2 id="done-history-title">Completed tasks</h2>
+          </div>
+          <button class="icon-button" value="cancel" type="button" data-close-modal aria-label="Close">
+            <span aria-hidden="true">x</span>
+          </button>
+        </div>
+        <ol class="history-list" id="done-history-list"></ol>
       </form>
     </dialog>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -19,6 +19,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 html,
 body {
   min-height: 100%;
@@ -407,6 +411,20 @@ button {
   overflow-wrap: anywhere;
 }
 
+.task-card-compact {
+  gap: 4px;
+  padding: 10px 12px;
+}
+
+.task-card-compact h4 {
+  font-size: 14px;
+}
+
+.completed-date {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .task-card p {
   color: var(--muted);
   font-size: 13px;
@@ -479,6 +497,16 @@ button {
   color: var(--muted);
   font-size: 13px;
   padding: 14px;
+}
+
+.history-button {
+  background: #fff;
+  border: 1px dashed #cbd5e1;
+  border-radius: var(--radius);
+  color: var(--primary);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 10px;
 }
 
 .modal {
@@ -558,7 +586,7 @@ button {
   resize: vertical;
 }
 
-.codex-panel,
+.status-panel,
 .github-panel {
   background: #f8fafc;
   border: 1px solid var(--soft);
@@ -568,13 +596,13 @@ button {
   padding: 14px;
 }
 
-.codex-panel h3,
+.status-panel h3,
 .github-panel h3,
 .proposal-card h4 {
   margin: 0;
 }
 
-.codex-panel p,
+.status-panel p,
 .github-panel p,
 .proposal-card p {
   color: var(--muted);
@@ -584,6 +612,98 @@ button {
 
 .github-panel {
   background: #fff;
+}
+
+.status-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.status-grid div {
+  background: #fff;
+  border: 1px solid #dbe3ea;
+  border-radius: var(--radius);
+  padding: 10px;
+}
+
+.status-grid span {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.status-grid strong {
+  font-size: 14px;
+}
+
+.context-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.context-image {
+  border: 1px solid #dbe3ea;
+  border-radius: var(--radius);
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 8px;
+  position: relative;
+  width: 144px;
+}
+
+.context-image img {
+  aspect-ratio: 4 / 3;
+  border-radius: 6px;
+  object-fit: cover;
+  width: 100%;
+}
+
+.context-image figcaption {
+  color: var(--muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.context-image .icon-button {
+  position: absolute;
+  right: 6px;
+  top: 6px;
+}
+
+.input-summary {
+  background: #fff;
+  border: 1px solid var(--soft);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+}
+
+.input-summary summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.input-summary-body {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.summary-row {
+  display: grid;
+  gap: 4px;
+}
+
+.summary-row p {
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0;
+  white-space: pre-wrap;
 }
 
 .issue-link {
@@ -674,6 +794,44 @@ button {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.result-grid[hidden] {
+  display: none;
+}
+
+.history-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.history-item {
+  align-items: center;
+  border: 1px solid var(--soft);
+  border-radius: var(--radius);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 10px 12px;
+}
+
+.history-item button {
+  background: transparent;
+  border: 0;
+  color: #111827;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0;
+  text-align: left;
+}
+
+.history-item span {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .result-grid h4 {
@@ -845,5 +1003,14 @@ button {
 
   .result-grid {
     grid-template-columns: 1fr;
+  }
+
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .history-item {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -150,12 +150,16 @@ function normalizeStore(store) {
     task.labels ??= [];
     task.acceptanceCriteria ??= [];
     task.links ??= [];
+    task.contextImages = cleanContextImages(task.contextImages);
     task.githubRepo = cleanRepoName(task.githubRepo) || "";
     task.targetEnvironment = cleanString(task.targetEnvironment);
     task.codexHandoffStatus ??= "idle";
     task.codexReviewStatus ??= "idle";
     task.codexResultStatus ??= "idle";
     task.githubStatus ??= "idle";
+    if (task.columnId === "done") {
+      task.completedAt = cleanString(task.completedAt) || cleanString(task.githubIssueClosedAt) || cleanString(task.updatedAt);
+    }
   }
 
   backfillActivities(store);
@@ -236,6 +240,39 @@ function cleanList(value) {
   }
 
   return [];
+}
+
+function cleanContextImages(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => {
+      if (typeof item === "string") {
+        const src = cleanString(item);
+        return src ? { id: `context-${randomUUID().slice(0, 8)}`, name: "Screenshot", src } : null;
+      }
+
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+
+      const src = cleanString(item.src);
+      if (!src) {
+        return null;
+      }
+
+      return {
+        id: cleanString(item.id) || `context-${randomUUID().slice(0, 8)}`,
+        name: cleanString(item.name, "Screenshot"),
+        src,
+        type: cleanString(item.type),
+        size: Number(item.size) || undefined,
+        createdAt: cleanString(item.createdAt) || now(),
+      };
+    })
+    .filter(Boolean);
 }
 
 function recordActivity(store, task, type, message, meta = {}) {
@@ -356,6 +393,24 @@ function listMarkdown(items, fallback = "- none") {
   return list.length ? list.map((item) => `- ${item}`).join("\n") : fallback;
 }
 
+function contextImagesMarkdown(task) {
+  const images = cleanContextImages(task.contextImages);
+
+  if (!images.length) {
+    return "- none";
+  }
+
+  return images
+    .map((image) => {
+      if (/^https?:\/\//i.test(image.src)) {
+        return `- [${image.name}](${image.src})`;
+      }
+
+      return `- ${image.name} (stored on the board as screenshot context)`;
+    })
+    .join("\n");
+}
+
 function githubIssueMarkdown(store, task) {
   const project = requireProject(store, task.projectId);
   const targetRepo = githubRepoForTask(store, task);
@@ -374,6 +429,9 @@ function githubIssueMarkdown(store, task) {
     "",
     "## Links",
     listMarkdown(task.links),
+    "",
+    "## Screenshot Context",
+    contextImagesMarkdown(task),
     "",
     "## Target Repository",
     targetRepo || "No repository configured.",
@@ -1598,6 +1656,7 @@ async function handleApi(req, res, url) {
       targetEnvironment: cleanString(payload.targetEnvironment),
       labels: cleanList(payload.labels),
       acceptanceCriteria: cleanList(payload.acceptanceCriteria),
+      contextImages: cleanContextImages(payload.contextImages),
       notes: cleanString(payload.notes),
       links: cleanList(payload.links),
       codexHandoffStatus: "idle",
@@ -1957,6 +2016,11 @@ async function handleApi(req, res, url) {
       task.columnId = cleanString(payload.columnId, task.columnId);
       requireColumn(store, task.columnId);
       task.sortOrder = nextSortOrder(store, task.projectId, task.columnId);
+      if (task.columnId === "done") {
+        task.completedAt = task.completedAt || now();
+      } else if (previousColumnId === "done") {
+        task.completedAt = "";
+      }
     }
 
     for (const key of ["title", "description", "priority", "size", "targetEnvironment", "notes"]) {
@@ -1977,6 +2041,10 @@ async function handleApi(req, res, url) {
       if (payload[key] !== undefined) {
         task[key] = cleanList(payload[key]);
       }
+    }
+
+    if (payload.contextImages !== undefined) {
+      task.contextImages = cleanContextImages(payload.contextImages);
     }
 
     task.updatedAt = now();
@@ -2166,6 +2234,7 @@ async function handleApi(req, res, url) {
     }
 
     moveTaskToColumn(store, task, "done");
+    task.completedAt = acceptedAt;
     task.codexHandoffStatus = "accepted";
     task.codexResultStatus = "accepted";
     if (task.githubIssueNumber) {
@@ -2213,13 +2282,14 @@ async function handleApi(req, res, url) {
       task.githubChangeCommentUrl = githubComment.html_url;
       task.codexHandoffStatus = "cloud-triggered";
       task.codexResultStatus = "in-progress";
+      moveTaskToColumn(store, task, "doing");
       recordActivity(store, task, "changes-requested-github", "Changes requested and sent to Codex Cloud.", {
         resultId: result?.id,
         note,
         codexCommentUrl: githubComment.html_url,
       });
     } else {
-      moveTaskToColumn(store, task, "ready");
+      moveTaskToColumn(store, task, "doing");
       task.codexHandoffStatus = "changes-requested";
       task.codexResultStatus = "changes-requested";
       recordActivity(store, task, "changes-requested", "Changes requested.", {


### PR DESCRIPTION
## Summary
- Simplify the task modal around title, description, acceptance criteria, and screenshot context.
- Add local review/work status summaries, result-mode presentation, and screenshot-context persistence.
- Make completed cards compact and add a completed-task history modal for older Done items.
- Fix hidden UI sections so panels and fields marked `hidden` are actually suppressed.

## Validation
- `node --check server.mjs`
- `node --check public/app.js`
- Full local workflow screenshot pass through create, local review, handoff, result review, further directions, confirmation, Done, and completed history.

## Notes
- The workflow test used local APIs only; no GitHub or Codex Cloud task actions were triggered.