### PR TITLE
[codex] Add project-level Codex routing settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -21,12 +21,23 @@ const els = {
   newProjectButton: document.querySelector("#new-project-button"),
   newTaskButton: document.querySelector("#new-task-button"),
   projectColor: document.querySelector("#project-color"),
+  projectCodexMode: document.querySelector("#project-codex-mode"),
+  projectCodexProfile: document.querySelector("#project-codex-profile"),
+  projectDefaultBranch: document.querySelector("#project-default-branch"),
   projectDescription: document.querySelector("#project-description"),
   projectDescriptionInput: document.querySelector("#project-description-input"),
+  projectEnvironment: document.querySelector("#project-environment"),
   projectForm: document.querySelector("#project-form"),
+  projectGithubRepo: document.querySelector("#project-github-repo"),
   projectList: document.querySelector("#project-list"),
+  projectLocalWorkspace: document.querySelector("#project-local-workspace"),
   projectModal: document.querySelector("#project-modal"),
+  projectModalTitle: document.querySelector("#project-modal-title"),
   projectName: document.querySelector("#project-name"),
+  projectRouteSummary: document.querySelector("#project-route-summary"),
+  projectSettingsButton: document.querySelector("#project-settings-button"),
+  projectSubmitButton: document.querySelector("#project-submit-button"),
+  projectSyncGithub: document.querySelector("#project-sync-github"),
   projectTitle: document.querySelector("#project-title"),
   proposalCard: document.querySelector("#proposal-card"),
   proposalDetails: document.querySelector("#proposal-details"),
@@ -148,6 +159,33 @@ function projectForTask(task) {
 
 function targetGithubRepo(task) {
   return task?.githubRepo || projectForTask(task)?.githubRepo || "";
+}
+
+function codexModeLabel(mode) {
+  if (mode === "cloud") {
+    return "Codex Cloud";
+  }
+
+  if (mode === "local") {
+    return "Local Codex";
+  }
+
+  return "Ask each time";
+}
+
+function projectRouteSummary(project) {
+  if (!project) {
+    return "";
+  }
+
+  const parts = [
+    codexModeLabel(project.codexTargetMode),
+    project.githubRepo ? project.githubRepo : "No GitHub repository",
+    project.localWorkspacePath ? `Workspace: ${project.localWorkspacePath}` : "",
+    project.defaultBranch ? `Branch: ${project.defaultBranch}` : "",
+  ].filter(Boolean);
+
+  return parts.join(" · ");
 }
 
 function allProjectTasks(projectId = currentProjectId) {
@@ -455,12 +493,16 @@ function renderHeader() {
   if (!project) {
     els.projectTitle.textContent = "No project";
     els.projectDescription.textContent = "";
+    els.projectRouteSummary.textContent = "";
+    els.projectSettingsButton.disabled = true;
     return;
   }
 
   els.projectTitle.textContent = project.name;
   els.projectDescription.textContent = project.description;
+  els.projectRouteSummary.textContent = projectRouteSummary(project);
   els.projectColor.style.background = project.color;
+  els.projectSettingsButton.disabled = false;
 }
 
 function renderStats() {
@@ -707,6 +749,26 @@ function openDoneHistory() {
   if (!els.doneHistoryModal.open) {
     els.doneHistoryModal.showModal();
   }
+}
+
+function openProjectModal(project = null) {
+  els.projectForm.dataset.projectId = project?.id ?? "";
+  els.projectModalTitle.textContent = project ? "Project settings" : "New project";
+  els.projectSubmitButton.textContent = project ? "Save project" : "Create project";
+  els.projectName.value = text(project?.name);
+  els.projectDescriptionInput.value = text(project?.description);
+  document.querySelector("#project-color-input").value = text(project?.color) || "#334155";
+  els.projectGithubRepo.value = text(project?.githubRepo);
+  els.projectCodexMode.value = ["cloud", "local", "ask"].includes(project?.codexTargetMode)
+    ? project.codexTargetMode
+    : "ask";
+  els.projectCodexProfile.value = text(project?.codexProfile);
+  els.projectLocalWorkspace.value = text(project?.localWorkspacePath);
+  els.projectDefaultBranch.value = text(project?.defaultBranch) || "main";
+  els.projectEnvironment.value = text(project?.targetEnvironment);
+  els.projectSyncGithub.checked = project?.syncGithub !== false;
+  els.projectModal.showModal();
+  els.projectName.focus();
 }
 
 function fillColumnOptions(selectedColumnId) {
@@ -1133,10 +1195,14 @@ els.taskContextInput.addEventListener("change", async () => {
 });
 
 els.newProjectButton.addEventListener("click", () => {
-  els.projectName.value = "";
-  els.projectDescriptionInput.value = "";
-  els.projectModal.showModal();
-  els.projectName.focus();
+  openProjectModal();
+});
+
+els.projectSettingsButton.addEventListener("click", () => {
+  const project = currentProject();
+  if (project) {
+    openProjectModal(project);
+  }
 });
 
 document.querySelectorAll("[data-close-modal]").forEach((button) => {
@@ -1377,10 +1443,18 @@ els.requestChangesButton.addEventListener("click", async () => {
 
 els.projectForm.addEventListener("submit", async (event) => {
   event.preventDefault();
+  const projectId = els.projectForm.dataset.projectId;
   const payload = {
     name: els.projectName.value.trim(),
     description: els.projectDescriptionInput.value.trim(),
     color: document.querySelector("#project-color-input").value,
+    githubRepo: els.projectGithubRepo.value.trim(),
+    codexTargetMode: els.projectCodexMode.value,
+    codexProfile: els.projectCodexProfile.value.trim(),
+    localWorkspacePath: els.projectLocalWorkspace.value.trim(),
+    defaultBranch: els.projectDefaultBranch.value.trim() || "main",
+    targetEnvironment: els.projectEnvironment.value.trim(),
+    syncGithub: els.projectSyncGithub.checked,
   };
 
   if (!payload.name) {
@@ -1388,14 +1462,14 @@ els.projectForm.addEventListener("submit", async (event) => {
     return;
   }
 
-  const nextStore = await api("/api/projects", {
-    method: "POST",
+  const nextStore = await api(projectId ? `/api/projects/${projectId}` : "/api/projects", {
+    method: projectId ? "PATCH" : "POST",
     body: JSON.stringify(payload),
   });
-  currentProjectId = nextStore.selectedProjectId;
+  currentProjectId = projectId || nextStore.selectedProjectId;
   setStore(nextStore);
   els.projectModal.close();
-  showToast("Project created");
+  showToast(projectId ? "Project settings saved" : "Project created");
 });
 
 els.authForm.addEventListener("submit", async (event) => {

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@
               <p class="eyebrow" id="project-kicker">Current project</p>
               <h2 id="project-title">Loading</h2>
               <p id="project-description"></p>
+              <p class="project-route-summary" id="project-route-summary"></p>
             </div>
           </div>
 
@@ -44,6 +45,7 @@
               <span class="visually-hidden">Search tasks</span>
               <input id="search-input" type="search" placeholder="Search tasks" />
             </label>
+            <button class="ghost-button" id="project-settings-button" type="button">Project settings</button>
             <button class="primary-button" id="new-task-button" type="button">New task</button>
           </div>
         </header>
@@ -201,7 +203,7 @@
         <div class="modal-header">
           <div>
             <p class="eyebrow">Project</p>
-            <h2>New project</h2>
+            <h2 id="project-modal-title">New project</h2>
           </div>
           <button class="icon-button" value="cancel" type="button" data-close-modal aria-label="Close">
             <span aria-hidden="true">x</span>
@@ -223,8 +225,47 @@
           <input id="project-color-input" name="color" type="color" value="#334155" />
         </label>
 
+        <label class="field">
+          <span>GitHub repository</span>
+          <input id="project-github-repo" name="githubRepo" placeholder="owner/repository" />
+        </label>
+
+        <label class="field">
+          <span>Codex target mode</span>
+          <select id="project-codex-mode" name="codexTargetMode">
+            <option value="ask">Ask each time</option>
+            <option value="cloud">Codex Cloud</option>
+            <option value="local">Local Codex</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Codex project/profile</span>
+          <input id="project-codex-profile" name="codexProfile" placeholder="Optional profile name" />
+        </label>
+
+        <label class="field">
+          <span>Local workspace path</span>
+          <input id="project-local-workspace" name="localWorkspacePath" placeholder="C:\path\to\workspace" />
+        </label>
+
+        <label class="field">
+          <span>Default branch</span>
+          <input id="project-default-branch" name="defaultBranch" placeholder="main" />
+        </label>
+
+        <label class="field">
+          <span>Environment guidance</span>
+          <textarea id="project-environment" name="targetEnvironment" rows="3"></textarea>
+        </label>
+
+        <label class="checkbox-field">
+          <input id="project-sync-github" name="syncGithub" type="checkbox" checked />
+          <span>Sync GitHub results for this project</span>
+        </label>
+
         <div class="modal-footer">
-          <button class="primary-button" type="submit">Create project</button>
+          <button class="primary-button" id="project-submit-button" type="submit">Create project</button>
         </div>
       </form>
     </dialog>

--- a/public/styles.css
+++ b/public/styles.css
@@ -208,6 +208,14 @@ button {
   max-width: 760px;
 }
 
+.project-route-summary {
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+}
+
 .topbar-actions {
   align-items: center;
   display: flex;
@@ -584,6 +592,23 @@ button {
   min-height: 92px;
   padding: 10px;
   resize: vertical;
+}
+
+.checkbox-field {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.checkbox-field input {
+  height: 18px;
+  width: 18px;
+}
+
+.checkbox-field span {
+  color: #374151;
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .status-panel,

--- a/server.mjs
+++ b/server.mjs
@@ -112,7 +112,7 @@ async function ensureDataFile() {
 
 function createEmptyStore() {
   return {
-    version: 3,
+    version: 5,
     selectedProjectId: null,
     columns: [
       { id: "backlog", name: "Backlog", description: "Ideas, rough requests, and parking-lot work." },
@@ -132,7 +132,7 @@ function createEmptyStore() {
 }
 
 function normalizeStore(store) {
-  store.version = Math.max(Number(store.version) || 1, 4);
+  store.version = Math.max(Number(store.version) || 1, 5);
   store.columns ??= createEmptyStore().columns;
   store.projects ??= [];
   store.tasks ??= [];
@@ -143,7 +143,7 @@ function normalizeStore(store) {
   store.githubExports ??= [];
 
   for (const project of store.projects) {
-    project.githubRepo = cleanRepoName(project.githubRepo) || defaultGithubRepo || "";
+    normalizeProjectRouting(project);
   }
 
   for (const task of store.tasks) {
@@ -240,6 +240,22 @@ function cleanList(value) {
   }
 
   return [];
+}
+
+function cleanCodexTargetMode(value, fallback = "ask") {
+  const mode = cleanString(value, fallback).toLowerCase();
+  return ["cloud", "local", "ask"].includes(mode) ? mode : fallback;
+}
+
+function normalizeProjectRouting(project) {
+  project.githubRepo = cleanRepoName(project.githubRepo) || defaultGithubRepo || "";
+  project.codexTargetMode = cleanCodexTargetMode(project.codexTargetMode);
+  project.codexProfile = cleanString(project.codexProfile);
+  project.localWorkspacePath = cleanString(project.localWorkspacePath);
+  project.defaultBranch = cleanString(project.defaultBranch, "main");
+  project.targetEnvironment = cleanString(project.targetEnvironment);
+  project.syncGithub = project.syncGithub === false ? false : true;
+  return project;
 }
 
 function cleanContextImages(value) {
@@ -413,8 +429,9 @@ function contextImagesMarkdown(task) {
 
 function githubIssueMarkdown(store, task) {
   const project = requireProject(store, task.projectId);
-  const targetRepo = githubRepoForTask(store, task);
-  const targetEnvironment = cleanString(task.targetEnvironment) || "No environment guidance provided.";
+  const routing = projectRoutingForTask(store, task);
+  const targetRepo = routing.githubRepo;
+  const targetEnvironment = routing.targetEnvironment || "No environment guidance provided.";
 
   return [
     "## Task",
@@ -448,13 +465,19 @@ function githubIssueMarkdown(store, task) {
     `- Labels: ${(task.labels ?? []).join(", ") || "none"}`,
     `- Target repository: ${targetRepo || "none"}`,
     `- Target environment: ${targetEnvironment}`,
+    `- Codex target mode: ${routing.codexTargetMode}`,
+    `- Codex project/profile: ${routing.codexProfile || "none"}`,
+    `- Local workspace: ${routing.localWorkspacePath || "none"}`,
+    `- Default branch: ${routing.defaultBranch || "none"}`,
+    `- GitHub sync: ${routing.syncGithub ? "enabled" : "disabled"}`,
   ].join("\n");
 }
 
 function codexCloudComment(store, task) {
   const project = requireProject(store, task.projectId);
-  const targetRepo = githubRepoForTask(store, task);
-  const targetEnvironment = cleanString(task.targetEnvironment) || "not specified";
+  const routing = projectRoutingForTask(store, task);
+  const targetRepo = routing.githubRepo;
+  const targetEnvironment = routing.targetEnvironment || "not specified";
 
   return [
     "@codex please take this task.",
@@ -473,13 +496,16 @@ function codexCloudComment(store, task) {
     `Board task ID: ${task.id}`,
     `Target repository: ${targetRepo || "not configured"}`,
     `Target environment: ${targetEnvironment}`,
+    `Codex project/profile: ${routing.codexProfile || "not configured"}`,
+    `Default branch: ${routing.defaultBranch || "not configured"}`,
   ].join("\n");
 }
 
 function codexCloudReviewComment(store, task, review) {
   const project = requireProject(store, task.projectId);
-  const targetRepo = githubRepoForTask(store, task);
-  const targetEnvironment = cleanString(task.targetEnvironment);
+  const routing = projectRoutingForTask(store, task);
+  const targetRepo = routing.githubRepo;
+  const targetEnvironment = routing.targetEnvironment;
 
   return [
     "@codex please review this task for implementation readiness only. Do not implement code.",
@@ -521,6 +547,7 @@ function codexCloudReviewComment(store, task, review) {
     `Board task ID: ${task.id}`,
     `Target repository: ${targetRepo || "not configured"}`,
     `Target environment: ${targetEnvironment || "not specified"}`,
+    `Codex project/profile: ${routing.codexProfile || "not configured"}`,
     `Review ID: ${review.id}`,
   ].join("\n");
 }
@@ -528,8 +555,9 @@ function codexCloudReviewComment(store, task, review) {
 function codexCloudFollowUpComment(store, task, note = "") {
   const project = requireProject(store, task.projectId);
   const guidance = cleanString(note);
-  const targetRepo = githubRepoForTask(store, task);
-  const targetEnvironment = cleanString(task.targetEnvironment) || "not specified";
+  const routing = projectRoutingForTask(store, task);
+  const targetRepo = routing.githubRepo;
+  const targetEnvironment = routing.targetEnvironment || "not specified";
 
   return [
     "@codex please continue this task from the updated board card in this same GitHub issue thread.",
@@ -547,6 +575,8 @@ function codexCloudFollowUpComment(store, task, note = "") {
     `Board task ID: ${task.id}`,
     `Target repository: ${targetRepo || "not configured"}`,
     `Target environment: ${targetEnvironment}`,
+    `Codex project/profile: ${routing.codexProfile || "not configured"}`,
+    `Default branch: ${routing.defaultBranch || "not configured"}`,
   ].join("\n");
 }
 
@@ -631,8 +661,9 @@ async function ensureGithubIssueForTask(store, task, repo, timestamp, { status =
 
 function buildTaskPacket(store, task, purpose) {
   const project = requireProject(store, task.projectId);
-  const targetRepo = githubRepoForTask(store, task);
-  const targetEnvironment = cleanString(task.targetEnvironment) || "not specified";
+  const routing = projectRoutingForTask(store, task);
+  const targetRepo = routing.githubRepo;
+  const targetEnvironment = routing.targetEnvironment || "not specified";
 
   return [
     `# ${purpose}: ${task.title}`,
@@ -645,6 +676,11 @@ function buildTaskPacket(store, task, purpose) {
     `Labels: ${(task.labels ?? []).join(", ") || "none"}`,
     `Target repository: ${targetRepo || "not configured"}`,
     `Target environment: ${targetEnvironment}`,
+    `Codex target mode: ${routing.codexTargetMode}`,
+    `Codex project/profile: ${routing.codexProfile || "not configured"}`,
+    `Local workspace: ${routing.localWorkspacePath || "not configured"}`,
+    `Default branch: ${routing.defaultBranch || "not configured"}`,
+    `GitHub sync: ${routing.syncGithub ? "enabled" : "disabled"}`,
     "",
     "## Context",
     task.description || "No description provided.",
@@ -680,7 +716,8 @@ function inferLabels(task) {
   return Array.from(existing).slice(0, 6);
 }
 
-function buildLocalReviewProposal(task) {
+function buildLocalReviewProposal(store, task) {
+  const routing = projectRoutingForTask(store, task);
   const acceptanceCriteria = task.acceptanceCriteria?.length
     ? task.acceptanceCriteria
     : [
@@ -703,8 +740,8 @@ function buildLocalReviewProposal(task) {
     description: task.description || task.title,
     priority: task.priority || "Medium",
     size: task.size || "M",
-    githubRepo: cleanRepoName(task.githubRepo),
-    targetEnvironment: cleanString(task.targetEnvironment),
+    githubRepo: routing.githubRepo,
+    targetEnvironment: routing.targetEnvironment,
     labels: inferLabels(task),
     acceptanceCriteria,
     links: task.links ?? [],
@@ -815,8 +852,21 @@ async function githubRequest(repo, path, options = {}) {
 }
 
 function githubRepoForTask(store, task) {
+  return projectRoutingForTask(store, task).githubRepo;
+}
+
+function projectRoutingForTask(store, task) {
   const project = requireProject(store, task.projectId);
-  return cleanRepoName(task.githubRepo) || cleanRepoName(project.githubRepo) || defaultGithubRepo;
+
+  return {
+    githubRepo: cleanRepoName(task.githubRepo) || cleanRepoName(project.githubRepo) || defaultGithubRepo || "",
+    codexTargetMode: cleanCodexTargetMode(project.codexTargetMode),
+    codexProfile: cleanString(project.codexProfile),
+    localWorkspacePath: cleanString(project.localWorkspacePath),
+    defaultBranch: cleanString(project.defaultBranch, "main"),
+    targetEnvironment: cleanString(task.targetEnvironment) || cleanString(project.targetEnvironment),
+    syncGithub: project.syncGithub !== false,
+  };
 }
 
 function htmlToText(value = "") {
@@ -1585,6 +1635,12 @@ async function handleApi(req, res, url) {
       description: cleanString(payload.description),
       color: cleanString(payload.color, "#334155"),
       githubRepo: cleanRepoName(payload.githubRepo) || defaultGithubRepo || "",
+      codexTargetMode: cleanCodexTargetMode(payload.codexTargetMode),
+      codexProfile: cleanString(payload.codexProfile),
+      localWorkspacePath: cleanString(payload.localWorkspacePath),
+      defaultBranch: cleanString(payload.defaultBranch, "main"),
+      targetEnvironment: cleanString(payload.targetEnvironment),
+      syncGithub: payload.syncGithub === false ? false : true,
       createdAt,
       updatedAt: createdAt,
     };
@@ -1620,10 +1676,35 @@ async function handleApi(req, res, url) {
       project.githubRepo = cleanRepoName(payload.githubRepo);
     }
 
+    if (payload.codexTargetMode !== undefined) {
+      project.codexTargetMode = cleanCodexTargetMode(payload.codexTargetMode);
+    }
+
+    if (payload.codexProfile !== undefined) {
+      project.codexProfile = cleanString(payload.codexProfile);
+    }
+
+    if (payload.localWorkspacePath !== undefined) {
+      project.localWorkspacePath = cleanString(payload.localWorkspacePath);
+    }
+
+    if (payload.defaultBranch !== undefined) {
+      project.defaultBranch = cleanString(payload.defaultBranch, "main");
+    }
+
+    if (payload.targetEnvironment !== undefined) {
+      project.targetEnvironment = cleanString(payload.targetEnvironment);
+    }
+
+    if (payload.syncGithub !== undefined) {
+      project.syncGithub = payload.syncGithub === false ? false : true;
+    }
+
     if (payload.selected === true) {
       store.selectedProjectId = project.id;
     }
 
+    normalizeProjectRouting(project);
     project.updatedAt = now();
     await saveStore(store);
     return jsonResponse(res, 200, store);
@@ -1946,7 +2027,7 @@ async function handleApi(req, res, url) {
 
     if (useLocalReview) {
       review.proposal = {
-        ...buildLocalReviewProposal(task),
+        ...buildLocalReviewProposal(store, task),
         proposedAt: createdAt,
       };
     } else {


### PR DESCRIPTION
## Summary
- Add project settings for GitHub repository, Codex target mode, Codex profile, local workspace path, default branch, environment guidance, and GitHub sync preference.
- Show the resolved project routing summary in the board header.
- Persist and normalize project routing fields in the server store.
- Include inherited project routing details in task packets and GitHub/Codex handoff text.

## Validation
- `node --check server.mjs`
- `node --check public/app.js`
- Browser verification of Project settings modal, route summary, and API persistence
- Health check: 200