### PR TITLE
[codex] Keep task review route-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The first board is seeded for Pabal. Add more projects from the sidebar when you
 The intended flow is:
 
 1. Create a task in Backlog.
-2. Press `Request task review`. With GitHub configured, this creates or reuses the task's GitHub issue and posts a review-only `@codex` request.
+2. Press `Request task review`. This follows the project route: Local creates a readiness proposal on the board, Cloud creates or reuses the task's GitHub issue and posts a review-only `@codex` request, and Ask prompts for the review route.
 3. When Codex Cloud posts the review proposal, the board syncs it back into the card. Read the proposal, edit the card if needed, then press `Apply proposal`.
 4. Press `Start Codex` when you want implementation to begin. The project route decides whether this starts Codex Cloud or Local Codex. If the review already created a GitHub issue, Codex Cloud implementation is triggered in that same issue thread. The task moves to In Progress.
 5. The server checks GitHub automatically. When a Codex completion comment appears, the result is copied into the card and the task moves to Review.

--- a/public/app.js
+++ b/public/app.js
@@ -499,6 +499,23 @@ function chooseCodexStartMode(task) {
   return window.confirm("Start Local Codex instead?") ? "local" : null;
 }
 
+function chooseCodexReviewMode(task) {
+  const route = resolvedTaskRoute(task);
+
+  if (route.mode === "cloud" || route.mode === "local") {
+    return route.mode;
+  }
+
+  if (route.githubRepo) {
+    const useCloudReview = window.confirm(`Request a Codex Cloud readiness review in ${route.githubRepo}?`);
+    if (useCloudReview) {
+      return "cloud";
+    }
+  }
+
+  return window.confirm("Create a local review proposal instead?") ? "local" : null;
+}
+
 function renderList(target, items, emptyText) {
   target.replaceChildren();
   const values = (items ?? []).filter(Boolean);
@@ -1428,16 +1445,21 @@ els.requestReviewButton.addEventListener("click", async () => {
       throw new Error("Save the task before requesting review.");
     }
 
+    const mode = chooseCodexReviewMode(task);
+    if (!mode) {
+      return;
+    }
+
     const nextStore = await api(`/api/tasks/${task.id}/review`, {
       method: "POST",
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mode }),
     });
     setStore(nextStore);
     const updatedTask = nextStore.tasks.find((item) => item.id === task.id);
     if (updatedTask) {
       openTaskModal(updatedTask);
     }
-    showToast(updatedTask?.codexReviewStatus === "proposed" ? "Review proposal ready" : "Codex review requested");
+    showToast(updatedTask?.codexReviewStatus === "proposed" ? "Local review proposal ready" : "Codex Cloud review requested");
   } catch (error) {
     showToast(error.message);
   }

--- a/server.mjs
+++ b/server.mjs
@@ -2000,16 +2000,19 @@ async function handleApi(req, res, url) {
     const store = await loadStore();
     const task = requireTask(store, segments[2]);
     const project = requireProject(store, task.projectId);
-    const repo = cleanRepoName(payload.repo) || githubRepoForTask(store, task);
+    const routing = projectRoutingForTask(store, task);
+    const requestedMode = cleanCodexTargetMode(payload.mode, routing.codexTargetMode);
+    const repo = cleanRepoName(payload.repo) || routing.githubRepo;
     const createdAt = now();
     const packet = buildTaskPacket(store, task, "Codex task review request");
-    const useLocalReview = payload.mode === "local" || !githubToken || !repo;
+    const useLocalReview = requestedMode === "local" || !githubToken || !repo;
     const review = {
       id: `review-${randomUUID().slice(0, 8)}`,
       taskId: task.id,
       projectId: project.id,
       status: useLocalReview ? "proposed" : "cloud-triggered",
       reviewMode: useLocalReview ? "local" : "github-codex",
+      routeMode: requestedMode,
       requestNote: cleanString(payload.note),
       createdAt,
       updatedAt: createdAt,


### PR DESCRIPTION
## Summary
- Make Request task review resolve the project/task route before choosing local versus Codex Cloud review.
- Keep the review action explicitly review-only: local creates a proposal, cloud posts the existing review-only @codex request, and neither path starts implementation.
- Update README workflow text for route-aware review behavior.

## Validation
- `node --check public/app.js`
- `node --check server.mjs`
- `git diff --check`
- Restored local API test: project route `local` produced `codexReviewStatus=proposed`, `reviewMode=local`, `routeMode=local`, and left GitHub status idle.