### PR TITLE
Add fridge recipe prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ A small local task board for keeping Codex-ready work organized across projects.
 node server.mjs
 ```
 
-Open:
+Open the kanban board:
 
 ```text
 http://localhost:3001
+```
+
+Open the fridge recipe prototype:
+
+```text
+http://localhost:3001/recipe.html
 ```
 
 Secure local start:

--- a/public/recipe.css
+++ b/public/recipe.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+  --bg: #fff7ed;
+  --card: #ffffff;
+  --ink: #1f2937;
+  --muted: #667085;
+  --line: #fed7aa;
+  --primary: #0f766e;
+  --primary-dark: #115e59;
+  --accent: #c2410c;
+  --danger: #b42318;
+  --shadow: 0 20px 50px rgba(154, 52, 18, 0.14);
+  --radius: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(251, 146, 60, 0.35), transparent 34rem),
+    linear-gradient(180deg, #fff7ed 0%, #fffbeb 100%);
+  color: var(--ink);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  margin: 0;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.recipe-app {
+  display: grid;
+  gap: 24px;
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 28px;
+}
+
+.hero,
+.planner-card,
+.results-section,
+.library-section,
+.recipe-card,
+.library-item,
+.empty-state {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  overflow: hidden;
+  padding: clamp(28px, 7vw, 72px);
+  position: relative;
+}
+
+.hero::after {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.16), rgba(194, 65, 12, 0.18));
+  border-radius: 999px;
+  content: "";
+  height: 190px;
+  position: absolute;
+  right: -72px;
+  top: -68px;
+  width: 190px;
+}
+
+.eyebrow,
+.recipe-type,
+.library-item p {
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(36px, 8vw, 78px);
+  letter-spacing: -0.07em;
+  line-height: 0.95;
+  max-width: 820px;
+}
+
+.hero p:last-child {
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1.65;
+  margin-bottom: 0;
+  max-width: 720px;
+}
+
+.planner-card,
+.results-section,
+.library-section {
+  padding: clamp(18px, 4vw, 28px);
+}
+
+.card-heading,
+.section-title-row,
+.recipe-card-header,
+.library-item {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.voice-status {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  border-radius: 999px;
+  color: var(--primary-dark);
+  font-size: 13px;
+  padding: 8px 12px;
+}
+
+.recipe-form {
+  display: grid;
+  gap: 18px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field span {
+  font-weight: 800;
+}
+
+.field input,
+.field textarea {
+  background: #fff;
+  border: 1px solid #fdba74;
+  border-radius: 14px;
+  color: var(--ink);
+  outline: none;
+  padding: 14px 16px;
+  width: 100%;
+}
+
+.field input:focus,
+.field textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.15);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.primary-button,
+.secondary-button,
+.save-button {
+  border-radius: 999px;
+  font-weight: 800;
+  min-height: 46px;
+  padding: 0 18px;
+}
+
+.primary-button,
+.save-button {
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  color: white;
+}
+
+.primary-button:hover,
+.save-button:hover {
+  background: var(--primary-dark);
+}
+
+.secondary-button {
+  background: #fff;
+  border: 1px solid #fdba74;
+  color: var(--ink);
+}
+
+.text-button {
+  background: transparent;
+  border: 0;
+  color: var(--primary-dark);
+  font-weight: 800;
+  padding: 8px;
+}
+
+.text-button.danger {
+  color: var(--danger);
+}
+
+.proposal-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.recipe-card,
+.empty-state {
+  box-shadow: none;
+  padding: 20px;
+}
+
+.recipe-card.saved {
+  border-color: #99f6e4;
+}
+
+.recipe-summary,
+.library-item span,
+.empty-state p {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.detail-grid h4 {
+  margin: 0 0 8px;
+}
+
+.detail-grid ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.detail-grid li + li {
+  margin-top: 6px;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
+.empty-state.compact {
+  box-shadow: none;
+}
+
+.library-list {
+  display: grid;
+  gap: 12px;
+}
+
+.library-item {
+  box-shadow: none;
+  padding: 16px;
+}
+
+.library-item h3 {
+  margin-bottom: 6px;
+}
+
+@media (max-width: 820px) {
+  .recipe-app {
+    padding: 14px;
+  }
+
+  .card-heading,
+  .section-title-row,
+  .recipe-card-header,
+  .library-item {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .proposal-grid,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .primary-button,
+  .secondary-button,
+  .save-button {
+    width: 100%;
+  }
+}

--- a/public/recipe.html
+++ b/public/recipe.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fridge Ideas</title>
+    <link rel="stylesheet" href="/recipe.css" />
+  </head>
+  <body>
+    <main class="recipe-app">
+      <section class="hero" aria-labelledby="app-title">
+        <p class="eyebrow">Local prototype</p>
+        <h1 id="app-title">Turn what is in your fridge into dinner ideas.</h1>
+        <p>
+          Tell the app what ingredients you have and what you are craving. It will suggest three
+          distinct meals, show what each one uses, and call out any groceries you still need.
+        </p>
+      </section>
+
+      <section class="planner-card" aria-labelledby="planner-title">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Recipe planner</p>
+            <h2 id="planner-title">What do you have?</h2>
+          </div>
+          <span class="voice-status" id="voice-status" aria-live="polite">Voice input loading...</span>
+        </div>
+
+        <form id="recipe-form" class="recipe-form">
+          <label class="field">
+            <span>Fridge ingredients</span>
+            <textarea
+              id="ingredients-input"
+              name="ingredients"
+              rows="5"
+              placeholder="Example: eggs, spinach, rice, cheddar, chicken, tomatoes"
+              required
+            ></textarea>
+          </label>
+
+          <label class="field">
+            <span>What are you craving?</span>
+            <input
+              id="craving-input"
+              name="craving"
+              type="text"
+              placeholder="Example: cozy pasta, something spicy, quick breakfast"
+              required
+            />
+          </label>
+
+          <div class="form-actions">
+            <button class="primary-button" type="submit">Get three meal ideas</button>
+            <button class="secondary-button" id="dictate-button" type="button">Dictate ingredients</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="results-section" aria-labelledby="results-title">
+        <div class="section-title-row">
+          <div>
+            <p class="eyebrow">Fresh ideas</p>
+            <h2 id="results-title">Recipe proposals</h2>
+          </div>
+          <button class="text-button" id="clear-results-button" type="button">Clear results</button>
+        </div>
+        <div class="proposal-grid" id="proposal-grid" aria-live="polite">
+          <article class="empty-state">
+            <h3>Ready when you are.</h3>
+            <p>Add ingredients and a craving to generate three starter recipes.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="library-section" aria-labelledby="library-title">
+        <div class="section-title-row">
+          <div>
+            <p class="eyebrow">Saved recipes</p>
+            <h2 id="library-title">Your library</h2>
+          </div>
+          <button class="text-button danger" id="clear-library-button" type="button">Clear library</button>
+        </div>
+        <div class="library-list" id="library-list" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <template id="proposal-template">
+      <article class="recipe-card">
+        <div class="recipe-card-header">
+          <div>
+            <p class="recipe-type"></p>
+            <h3></h3>
+          </div>
+          <button class="save-button" type="button">Save</button>
+        </div>
+        <p class="recipe-summary"></p>
+        <div class="detail-grid">
+          <div>
+            <h4>Uses from your fridge</h4>
+            <ul class="used-list"></ul>
+          </div>
+          <div>
+            <h4>Missing groceries</h4>
+            <ul class="missing-list"></ul>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script type="module" src="/recipe.js"></script>
+  </body>
+</html>

--- a/public/recipe.js
+++ b/public/recipe.js
@@ -1,0 +1,280 @@
+const libraryKey = "fridge-ideas-library-v1";
+
+const pantryStaples = ["salt", "pepper", "olive oil", "water"];
+
+const recipeBlueprints = [
+  {
+    type: "Fast skillet",
+    title: "Craveable skillet hash",
+    preferred: ["potato", "sweet potato", "onion", "pepper", "egg", "cheese", "sausage", "chicken"],
+    fallback: ["onion", "garlic", "egg"],
+    missing: ["onion", "eggs", "fresh herbs"],
+    summary: (craving) => `A one-pan option with crispy edges and a ${craving || "comfort-food"} feel.`,
+  },
+  {
+    type: "Bowl",
+    title: "Fridge-clearing grain bowl",
+    preferred: ["rice", "quinoa", "couscous", "chicken", "tofu", "beans", "spinach", "tomato", "avocado"],
+    fallback: ["rice", "greens", "beans"],
+    missing: ["rice", "lemon", "yogurt"],
+    summary: (craving) => `A flexible bowl that layers your ingredients with a bright ${craving || "fresh"} finish.`,
+  },
+  {
+    type: "Pasta or noodles",
+    title: "Cozy pantry pasta",
+    preferred: ["pasta", "noodles", "tomato", "cheese", "spinach", "mushroom", "chicken", "cream"],
+    fallback: ["pasta", "garlic", "parmesan"],
+    missing: ["pasta", "parmesan", "garlic"],
+    summary: (craving) => `A saucy pasta-style meal tuned for a ${craving || "cozy"} craving.`,
+  },
+  {
+    type: "Wrap",
+    title: "Loaded fridge wrap",
+    preferred: ["tortilla", "bread", "chicken", "turkey", "egg", "lettuce", "tomato", "cheese", "hummus"],
+    fallback: ["tortillas", "greens", "sauce"],
+    missing: ["tortillas", "crunchy lettuce", "sauce"],
+    summary: (craving) => `A handheld meal with crisp, creamy, and ${craving || "satisfying"} bites.`,
+  },
+  {
+    type: "Soup",
+    title: "Simple simmer soup",
+    preferred: ["broth", "carrot", "celery", "onion", "chicken", "beans", "noodles", "rice", "tomato"],
+    fallback: ["broth", "onion", "carrot"],
+    missing: ["broth", "carrots", "crusty bread"],
+    summary: (craving) => `A low-effort soup for when you want something ${craving || "warming"}.`,
+  },
+];
+
+const els = {
+  form: document.querySelector("#recipe-form"),
+  ingredients: document.querySelector("#ingredients-input"),
+  craving: document.querySelector("#craving-input"),
+  proposalGrid: document.querySelector("#proposal-grid"),
+  proposalTemplate: document.querySelector("#proposal-template"),
+  libraryList: document.querySelector("#library-list"),
+  dictateButton: document.querySelector("#dictate-button"),
+  voiceStatus: document.querySelector("#voice-status"),
+  clearResultsButton: document.querySelector("#clear-results-button"),
+  clearLibraryButton: document.querySelector("#clear-library-button"),
+};
+
+let activeProposals = [];
+let recognition = null;
+
+function normalizeToken(value) {
+  return value.toLowerCase().replace(/[^a-z0-9 ]/g, "").trim();
+}
+
+function parseIngredients(value) {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,]+|\band\b/gi)
+        .map((item) => normalizeToken(item))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function ingredientMatches(ingredient, target) {
+  return ingredient.includes(target) || target.includes(ingredient);
+}
+
+function availableMatches(ingredients, targets) {
+  return targets.filter((target) => ingredients.some((ingredient) => ingredientMatches(ingredient, target)));
+}
+
+function missingItems(availableIngredients, candidates, usedItems) {
+  const missing = candidates.filter(
+    (item) => !availableIngredients.some((ingredient) => ingredientMatches(ingredient, item)) && !usedItems.includes(item),
+  );
+
+  return missing.length ? missing.slice(0, 3) : ["None needed"];
+}
+
+function scoreBlueprint(blueprint, ingredients, craving) {
+  const usedCount = availableMatches(ingredients, blueprint.preferred).length;
+  const cravingWords = normalizeToken(craving).split(/\s+/).filter(Boolean);
+  const cravingBonus = cravingWords.some((word) => `${blueprint.type} ${blueprint.title}`.toLowerCase().includes(word)) ? 2 : 0;
+  return usedCount * 3 + cravingBonus;
+}
+
+function generateProposals(userIngredients, craving) {
+  const availableIngredients = [...userIngredients, ...pantryStaples];
+  const sortedBlueprints = [...recipeBlueprints]
+    .sort((left, right) => scoreBlueprint(right, availableIngredients, craving) - scoreBlueprint(left, availableIngredients, craving))
+    .slice(0, 3);
+
+  return sortedBlueprints.map((blueprint, index) => {
+    const used = availableMatches(userIngredients, blueprint.preferred);
+    const displayedUsed = used.length ? used : userIngredients.slice(0, 3);
+    const missing = missingItems(availableIngredients, [...blueprint.missing, ...blueprint.fallback], displayedUsed);
+
+    return {
+      id: `${Date.now()}-${index}`,
+      type: blueprint.type,
+      title: blueprint.title,
+      summary: blueprint.summary(craving.trim()),
+      used: displayedUsed,
+      missing,
+      createdAt: new Date().toISOString(),
+    };
+  });
+}
+
+function loadLibrary() {
+  return JSON.parse(localStorage.getItem(libraryKey) || "[]");
+}
+
+function saveLibrary(recipes) {
+  localStorage.setItem(libraryKey, JSON.stringify(recipes));
+}
+
+function listItems(container, items) {
+  container.replaceChildren(
+    ...items.map((item) => {
+      const li = document.createElement("li");
+      li.textContent = item;
+      return li;
+    }),
+  );
+}
+
+function renderProposal(recipe) {
+  const fragment = els.proposalTemplate.content.cloneNode(true);
+  const card = fragment.querySelector(".recipe-card");
+  const saveButton = fragment.querySelector(".save-button");
+
+  fragment.querySelector(".recipe-type").textContent = recipe.type;
+  fragment.querySelector("h3").textContent = recipe.title;
+  fragment.querySelector(".recipe-summary").textContent = recipe.summary;
+  listItems(fragment.querySelector(".used-list"), recipe.used);
+  listItems(fragment.querySelector(".missing-list"), recipe.missing);
+
+  saveButton.addEventListener("click", () => {
+    const library = loadLibrary();
+    if (!library.some((savedRecipe) => savedRecipe.title === recipe.title && savedRecipe.summary === recipe.summary)) {
+      saveLibrary([recipe, ...library]);
+    }
+    saveButton.textContent = "Saved";
+    saveButton.disabled = true;
+    card.classList.add("saved");
+    renderLibrary();
+  });
+
+  return fragment;
+}
+
+function renderProposals(proposals) {
+  if (!proposals.length) {
+    els.proposalGrid.innerHTML = `
+      <article class="empty-state">
+        <h3>Ready when you are.</h3>
+        <p>Add ingredients and a craving to generate three starter recipes.</p>
+      </article>
+    `;
+    return;
+  }
+
+  els.proposalGrid.replaceChildren(...proposals.map(renderProposal));
+}
+
+function renderLibrary() {
+  const library = loadLibrary();
+
+  if (!library.length) {
+    els.libraryList.innerHTML = `
+      <article class="empty-state compact">
+        <h3>No saved recipes yet.</h3>
+        <p>Save any proposal to keep it in this browser.</p>
+      </article>
+    `;
+    return;
+  }
+
+  els.libraryList.replaceChildren(
+    ...library.map((recipe) => {
+      const article = document.createElement("article");
+      const details = document.createElement("div");
+      const type = document.createElement("p");
+      const title = document.createElement("h3");
+      const summary = document.createElement("span");
+      const removeButton = document.createElement("button");
+
+      article.className = "library-item";
+      type.textContent = recipe.type;
+      title.textContent = recipe.title;
+      summary.textContent = recipe.summary;
+      removeButton.className = "text-button danger";
+      removeButton.type = "button";
+      removeButton.textContent = "Remove";
+      removeButton.addEventListener("click", () => {
+        saveLibrary(loadLibrary().filter((savedRecipe) => savedRecipe.id !== recipe.id));
+        renderLibrary();
+      });
+
+      details.append(type, title, summary);
+      article.append(details, removeButton);
+      return article;
+    }),
+  );
+}
+
+function setupVoiceInput() {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+  if (!SpeechRecognition) {
+    els.voiceStatus.textContent = "Voice input unavailable; text input works.";
+    els.dictateButton.disabled = true;
+    els.dictateButton.textContent = "Voice unavailable";
+    return;
+  }
+
+  recognition = new SpeechRecognition();
+  recognition.continuous = false;
+  recognition.interimResults = false;
+  recognition.lang = "en-US";
+
+  recognition.addEventListener("start", () => {
+    els.voiceStatus.textContent = "Listening for ingredients...";
+    els.dictateButton.textContent = "Listening...";
+  });
+
+  recognition.addEventListener("result", (event) => {
+    const transcript = Array.from(event.results)
+      .map((result) => result[0].transcript)
+      .join(", ");
+    els.ingredients.value = [els.ingredients.value.trim(), transcript].filter(Boolean).join(", ");
+  });
+
+  recognition.addEventListener("end", () => {
+    els.voiceStatus.textContent = "Voice input ready.";
+    els.dictateButton.textContent = "Dictate ingredients";
+  });
+
+  els.voiceStatus.textContent = "Voice input ready.";
+}
+
+els.form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const ingredients = parseIngredients(els.ingredients.value);
+  activeProposals = generateProposals(ingredients, els.craving.value);
+  renderProposals(activeProposals);
+});
+
+els.dictateButton.addEventListener("click", () => {
+  recognition?.start();
+});
+
+els.clearResultsButton.addEventListener("click", () => {
+  activeProposals = [];
+  renderProposals(activeProposals);
+});
+
+els.clearLibraryButton.addEventListener("click", () => {
+  saveLibrary([]);
+  renderLibrary();
+});
+
+setupVoiceInput();
+renderLibrary();


### PR DESCRIPTION
### Motivation
- Provide a local, mobile-friendly prototype so users can enter fridge ingredients and cravings and receive three distinct meal proposals that show which available ingredients are used and which groceries are missing. 
- Let users save recipe proposals to a simple browser-local library so the MVP covers the requested persistence requirement for saved recipes.

### Description
- Added a new prototype UI at `public/recipe.html` with inputs for fridge ingredients and cravings, a dictate button, a proposal grid, and a saved-library section. 
- Implemented client-side recipe generation logic in `public/recipe.js` using a small set of recipe blueprints that score and return the top three proposals, list used fridge ingredients, and list missing grocery items. 
- Added Web Speech API dictation support with a text-input fallback and a browser-local persistence layer using `localStorage` for saved recipes. 
- Added responsive styling for mobile/desktop in `public/recipe.css` and updated the `README.md` to document the prototype URL (`/recipe.html`).

### Testing
- Ran syntax checks with `node --check server.mjs`, `node --check public/app.js`, and `node --check public/recipe.js`, all of which passed. 
- Launched the local server and fetched the static prototype assets via `curl` to verify `http://localhost:3001/recipe.html`, `recipe.js`, and `recipe.css` were served successfully. 
- Verified basic client behavior by loading the prototype (server started) and confirmed files are non-empty and present. 
- Attempted automated screenshot capture with Playwright via `npx`, but the attempt failed because the npm registry returned `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a23ee57f883288babd215eaa86e20)